### PR TITLE
Typo fixed and identified the issue.

### DIFF
--- a/app/joinUsForm/joinUsForm.tsx
+++ b/app/joinUsForm/joinUsForm.tsx
@@ -27,7 +27,7 @@ const joinUsFormSchema = z.object({
         .string({ required_error: "Roll number is required." })
         .min(5, { message: "Roll number must be at least 5 characters." }),
     branch: z
-        .string({ required_error: "Branch is required." })
+        .string({ required_error: "Branch is required." }) 
         .min(2, { message: "Branch must be at least 2 characters." }),
     college: z
         .string({ required_error: "College name is required." })
@@ -81,7 +81,7 @@ const JoinUsForm = () => {
 
             const result = await response.json();
             if (result.success) {
-                router.push("/joinUsFor/result");
+                router.push("/joinUsForm/result");
             } else {
                 console.error("Error submitting form:", result.error);
             }


### PR DESCRIPTION
Code fix:
- Fixed the typo on the route that would prevent from redirecting the user to the result page upon successfully submitting the form.

Now, the actual problem:
- The Google form, behind the scenes, requires a gmail to login.
- To make it work, ensure the settings are set this way:  

<img width="801" alt="Screenshot 2025-01-01 at 7 19 33 PM" src="https://github.com/user-attachments/assets/8424abf5-fceb-4ff1-8bca-5e111b94da76" />
